### PR TITLE
[bin] encode label name if it set as multibyte string

### DIFF
--- a/bin/labellio_classify
+++ b/bin/labellio_classify
@@ -16,7 +16,7 @@ def images(image_dir):
 def exec_batch(batch, classifier, label):
     paths, data = zip(*batch)
     for i, output in enumerate(classifier.forward_iter(data)):
-        print("{0}\t{1}\t{2}".format(paths[i], label.label(output.best), output.values))
+        print("{0}\t{1}\t{2}".format(paths[i], label.label(output.best).encode("utf-8"), output.values))
 
 
 def main(args):


### PR DESCRIPTION
- summary

if label is saved as multibyte string(such as Japanese) via Web-UI,
print(label.label(output.best)) will throw UnicodeEncodeError
- description

my label name  "ゴリラ"  causes this exception

```
Traceback (most recent call last):
  File "/home/vagrant/labellio_cli/bin/labellio_classify", line 55, in <module>
    main(get_parser().parse_args())
  File "/home/vagrant/labellio_cli/bin/labellio_classify", line 40, in main
    exec_batch(batch, classifier, label)
  File "/home/vagrant/labellio_cli/bin/labellio_classify", line 19, in exec_batch
    print("{0}\t{1}\t{2}".format(paths[i], label.label(output.best), output.values))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-2: ordinal not in range(128)
```
- will be fixed as

```
images/labellio/monkey.jpg      ゴリラ  [  2.30376329e-02   9.76935029e-01   2.73859241e-05]
```
